### PR TITLE
feat: split into two, implenting `take`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,13 @@
 
 ..  currentmodule:: pandas_uuid
 
-..  autoclass:: UuidExtensionArray
+..  autoclass:: BaseUuidArray
+
+..  autoclass:: UuidArray
+    :members: __arrow_array__
+    :special-members: __init__
+
+..  autoclass:: ArrowUuidArray
     :members: __arrow_array__
     :special-members: __init__
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,10 +8,8 @@
 ..  autoclass:: BaseUuidArray
 
 ..  autoclass:: UuidArray
-    :special-members: __init__
 
 ..  autoclass:: ArrowUuidArray
-    :special-members: __init__
 
 ..  autoclass:: UuidDtype
     :members: storage, na_value

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,15 +8,13 @@
 ..  autoclass:: BaseUuidArray
 
 ..  autoclass:: UuidArray
-    :members: __arrow_array__
     :special-members: __init__
 
 ..  autoclass:: ArrowUuidArray
-    :members: __arrow_array__
     :special-members: __init__
 
 ..  autoclass:: UuidDtype
-    :members: storage, na_value, __from_arrow__
+    :members: storage, na_value
 
 ..  autotype:: UuidStorage
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,17 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 # Fix up undocumented types using the `resolve_from_map` extension
 type_map = {
     ("py", "class", "NAType"): ("attr", "pandas.NA"),
+    **{
+        ("py", "class", f"pa.{cls}"): ("class", f"pyarrow.{cls}")
+        for cls in [
+            "Array",
+            "ChunkedArray",
+            "UuidArray",
+            "UuidScalar",
+            "UuidType",
+            "Scalar",
+        ]
+    },
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,9 @@ API
 ---
 
 ..  autosummary::
-    pandas_uuid.UuidExtensionArray
+    pandas_uuid.BaseUuidArray
+    pandas_uuid.UuidArray
+    pandas_uuid.ArrowUuidArray
     pandas_uuid.UuidDtype
     pandas_uuid.UuidStorage
     pandas_uuid.UuidLike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ installer = "uv"
 dependency-groups = ["typing"]
 
 [tool.hatch.envs.docs]
+features = ["pyarrow"]
 dependency-groups = ["typing", "doc"]
 scripts.build = "sphinx-build -M html docs docs/_build -W {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -513,25 +513,3 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):  # noqa: PLW1641
             other._pa_array.cast(pa.binary(16)),  # noqa: SLF001
         )
         return cast("BooleanArray", pd.array(result, dtype="boolean"))  # pyright: ignore[reportArgumentType]
-
-    # IO
-
-    @overload
-    def __arrow_array__(self, type: None = None) -> pa.Array[pa.UuidScalar]: ...
-    @overload
-    def __arrow_array__(self, type: _DT) -> pa.Array[pa.Scalar[_DT]]: ...
-    def __arrow_array__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self,
-        type: _DT | None = None,  # noqa: A002
-    ) -> pa.Array[pa.Scalar[_DT]] | pa.ChunkedArray[pa.Scalar[_DT]]:
-        """PyArrow extension API for :meth:`pyarrow.Array.from_pandas`.
-
-        See :ref:`pyarrow-integration` for an example
-        and :ref:`pyarrow:arrow_array_protocol` for details.
-        """
-        import pyarrow as pa
-
-        if type is None:
-            type = pa.uuid()  # pyright: ignore[reportAssignmentType] # noqa: A001
-
-        return self._pa_array.cast(type)  # pyright: ignore[reportReturnType]

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -262,10 +262,6 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
         return np.zeros(len(self), dtype=bool)
 
     @override
-    def copy(self, order: Literal["C", "F", "A", "K"] = "C") -> Self:
-        return self._simple_new(self._ndarray.copy(order))
-
-    @override
     @classmethod
     def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
         if len(to_concat) == 0:

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -158,7 +158,7 @@ class UuidDtype(ExtensionDtype):
 
         See :ref:`pyarrow-integration` for an example.
         """
-        return ArrowExtensionArray(array)
+        return ArrowUuidArray(array)
 
 
 class BaseUuidArray(ExtensionArray, abc.ABC):
@@ -217,8 +217,8 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):  # noqa: PLW1641
                 dtype=_UUID_NP_STORAGE_DTYPE,
             )
 
-        if getattr(self._ndarray, "ndim", 1) != 1:
-            msg = "Array only supports 1-d arrays"
+        if values.ndim != 1:
+            msg = "Array only supports 1-dimensional arrays"
             raise ValueError(msg)
 
         super().__init__(values)
@@ -385,6 +385,8 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):  # noqa: PLW1641
 
         # TODO: implement conversion between storage kinds
         # https://github.com/scverse/pandas-uuid/issues/12
+        if isinstance(values, np.ndarray) and values.dtype.kind != "O":
+            raise NotImplementedError
 
         if isinstance(values, pa.Array | pa.ChunkedArray):
             if dtype is not None and dtype.storage != "pyarrow":

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -252,7 +252,8 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
         item = check_array_indexer(self, item)
         return self._simple_new(self._ndarray[item])
 
-    # def __setitem__(self, index, value):
+    # TODO: def __setitem__(self, index, value)
+    # https://github.com/scverse/pandas-uuid/issues/15
 
     # Some methods are implemented by NumpyExtensionArray:
     # __len__, __eq__, nbytes, take
@@ -438,7 +439,8 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):
 
         return self._simple_new(values)
 
-    # def __setitem__(self, index, value):
+    # TODO: def __setitem__(self, index, value)
+    # https://github.com/scverse/pandas-uuid/issues/15
 
     # Some APIs are defined in ArrowExtensionArray/OpsMixin:
     # __len__, __eq__, nbytes, isna, take, copy

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -289,8 +289,10 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
 
     def _from_backing_data(self, values: NDArray[np.void]) -> Self:
         if values.dtype != _UUID_NP_STORAGE_DTYPE:
+            name = type(self).__name__
             msg = (
-                f"{type(self).__name__!r} only supports dtype={_UUID_NP_STORAGE_DTYPE}"
+                f"{name!r} only supports `values.dtype=='{_UUID_NP_STORAGE_DTYPE}'`, "
+                f"not {values.dtype}"
             )
             raise ValueError(msg)
         return super()._from_backing_data(values)

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -415,10 +415,7 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):  # noqa: PLW1641
 
     # ExtensionArray essential API (11 class attrs and methods)
 
-    @cached_property
-    @override
-    def dtype(self) -> UuidDtype:  # pyright: ignore[reportIncompatibleMethodOverride]
-        return self._dtype
+    dtype: UuidDtype  # pyright: ignore[reportIncompatibleMethodOverride]
 
     @override
     @classmethod
@@ -469,43 +466,13 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):  # noqa: PLW1641
 
     # def __setitem__(self, index, value):
 
-    @override
-    def __len__(self) -> int:
-        return len(self._pa_array)
+    # Some APIs are defined in ArrowExtensionArray:
+    # __len__, nbytes, isna, take, copy
 
     @unpack_zerodim_and_defer("__eq__")
     @override
     def __eq__(self, other: Sequence[UuidLike] | ArrowUuidArray) -> BooleanArray:  # pyright: ignore[reportIncompatibleMethodOverride]
         return self._cmp("eq", other)
-
-    @cached_property
-    @override
-    def nbytes(self) -> int:  # pyright: ignore[reportIncompatibleMethodOverride]
-        return self._pa_array.nbytes
-
-    @override
-    def isna(self) -> NDArray[np.bool_]:
-        return self._pa_array.is_null().to_numpy()
-
-    @override
-    def take(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self,
-        indices: TakeIndexer,
-        *,
-        allow_fill: bool = False,
-        fill_value: UUID | NAType | None = None,
-    ) -> Self:
-        # TODO: implement take for pyarrow
-        # https://github.com/scverse/pandas-uuid/issues/11
-        raise NotImplementedError
-
-    @override
-    def copy(self) -> Self:
-        return self._simple_new(
-            self._pa_array.copy()
-            if isinstance(self._pa_array, np.ndarray)
-            else self._pa_array
-        )
 
     @override
     @classmethod

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -53,7 +53,7 @@ from a sequence.
 
 if TYPE_CHECKING or sys.version_info >= (3, 13):
     _DT = TypeVar("_DT", bound="pa.DataType", default=pa.UuidType)
-else:
+else:  # pragma: no cover
     _DT = TypeVar("_DT", bound="pa.DataType")
 
 # 16 void bytes: 128 bit, every pattern valid, no funky behavior like 0 stripping.
@@ -204,8 +204,6 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
 
         # we treat object arrays as sequences (we can’t efficiently convert)
         if isinstance(values, np.ndarray) and values.dtype.kind != "O":
-            if dtype is not None and dtype.storage != "numpy":
-                raise NotImplementedError
             values = values.astype(_UUID_NP_STORAGE_DTYPE, copy=copy)
         else:
             # TODO: make construction from elements more efficient
@@ -365,9 +363,6 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):
             raise NotImplementedError
 
         if isinstance(values, pa.Array | pa.ChunkedArray):
-            if dtype is not None and dtype.storage != "pyarrow":
-                raise NotImplementedError
-
             self._pa_array = (
                 pa.chunked_array([values.cast(pa.uuid())])
                 if isinstance(values, pa.Array)

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -172,7 +172,7 @@ class BaseUuidArray(ExtensionArray, abc.ABC):
 
 
 class UuidArray(BaseUuidArray, NumpyExtensionArray):
-    """Extension array for string data in a :class:`numpy.ndarray`."""
+    """Extension array for storing uuid data in a :class:`numpy.ndarray`."""
 
     # Implementation details and convenience
 
@@ -309,10 +309,10 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
     # IO
 
     @overload
-    def __arrow_array__(self, type: None = None) -> pa.Array[pa.UuidScalar]: ...
+    def __arrow_array__(self, type: pa.UuidType | None = None) -> pa.UuidArray: ...
     @overload
     def __arrow_array__(self, type: _DT) -> pa.Array[pa.Scalar[_DT]]: ...
-    def __arrow_array__(
+    def __arrow_array__(  # pyright: ignore[reportInconsistentOverload]
         self,
         type: _DT | None = None,  # noqa: A002
     ) -> pa.Array[pa.Scalar[_DT]] | pa.ChunkedArray[pa.Scalar[_DT]]:
@@ -330,15 +330,15 @@ class UuidArray(BaseUuidArray, NumpyExtensionArray):
 
 
 class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):
-    """Extension array for uuid data in a :class:`pyarrow.ChunkedArray`."""
+    """Extension array for storing uuid data in a :class:`pyarrow.ChunkedArray`."""
 
-    _pa_array: pa.ChunkedArray[pa.Scalar[pa.UuidType]]
+    _pa_array: pa.ChunkedArray[pa.UuidScalar]
 
     def __init__(
         self,
         values: Iterable[UuidLike | NAType | None]
-        | pa.Array[pa.Scalar[pa.UuidType]]
-        | pa.ChunkedArray[pa.Scalar[pa.UuidType]],
+        | pa.UuidArray
+        | pa.ChunkedArray[pa.UuidScalar],
         *,
         dtype: UuidDtype | None = None,
     ) -> None:
@@ -367,7 +367,7 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):
                 pa.chunked_array([values.cast(pa.uuid())])
                 if isinstance(values, pa.Array)
                 else values.cast(pa.uuid())
-            )
+            )  # pyright: ignore[reportAttributeAccessIssue]
         else:
             # TODO: make construction from elements more efficient
             #       (both numpy and pyarrow)
@@ -380,7 +380,7 @@ class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):
                 ],
                 type=pa.uuid(),
             )
-            self._pa_array = pa.chunked_array([chunk])
+            self._pa_array = pa.chunked_array([chunk])  # pyright: ignore[reportAttributeAccessIssue]
 
     @cached_property
     @override

--- a/src/pandas_uuid/__init__.py
+++ b/src/pandas_uuid/__init__.py
@@ -3,47 +3,59 @@
 
 from __future__ import annotations
 
+import abc
+import sys
 from dataclasses import dataclass, field
 from functools import cache
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, ClassVar, Literal, cast, get_args, overload, override
+from typing import TYPE_CHECKING, Literal, TypeVar, cast, get_args, overload, override
 from uuid import UUID
 
 import numpy as np
 import pandas as pd
-from numpy.typing import NDArray
 from pandas.api.extensions import ExtensionArray, ExtensionDtype
 from pandas.api.indexers import check_array_indexer
+from pandas.arrays import ArrowExtensionArray, NumpyExtensionArray
 from pandas.core.algorithms import take
 from pandas.core.ops.common import unpack_zerodim_and_defer
 
 from . import _pyarrow as pa
 
 if TYPE_CHECKING:
-    import builtins
     from collections.abc import Iterable, Sequence
     from typing import Self
 
     import numpy.typing as npt
+    from numpy.typing import NDArray
 
     npt._ArrayLikeInt_co = None  # type: ignore  # noqa: PGH003, SLF001
 
     from pandas._libs.missing import NAType
-    from pandas._typing import ScalarIndexer, SequenceIndexer, TakeIndexer
+    from pandas._typing import AxisInt, ScalarIndexer, SequenceIndexer, TakeIndexer
     from pandas.arrays import BooleanArray
 
 
-__all__ = ["UuidDtype", "UuidExtensionArray", "UuidLike", "UuidStorage"]
+__all__ = [
+    "ArrowUuidArray",
+    "BaseUuidArray",
+    "UuidArray",
+    "UuidDtype",
+    "UuidLike",
+    "UuidStorage",
+]
 
 
 type UuidStorage = Literal["numpy", "pyarrow"]
 """Supported storage backend for :class:`~pandas_uuid.UuidDtype`."""
 type UuidLike = UUID | pa.UuidScalar | bytes | int | str
-"""Supported element types when creating a :class:`~pandas_uuid.UuidExtensionArray` \
+"""Supported element types when creating a :class:`~pandas_uuid.BaseUuidArray` \
 from a sequence.
 """
-type _UuidStorageArray = NDArray[np.void] | pa.UuidArray
 
+if TYPE_CHECKING or sys.version_info >= (3, 13):
+    _DT = TypeVar("_DT", bound="pa.DataType", default=pa.UuidType)
+else:
+    _DT = TypeVar("_DT", bound="pa.DataType")
 
 # 16 void bytes: 128 bit, every pattern valid, no funky behavior like 0 stripping.
 _UUID_NP_STORAGE_DTYPE: np.dtype[np.void] = np.dtype("V16")
@@ -103,13 +115,19 @@ class UuidDtype(ExtensionDtype):
 
     # ExtensionDtype essential API (3 class attrs and methods)
 
-    name: ClassVar[str] = "uuid"
-    type: ClassVar[builtins.type[UUID]] = UUID
-
-    @classmethod
+    @property
     @override
-    def construct_array_type(cls) -> type[UuidExtensionArray]:
-        return UuidExtensionArray
+    def name(self) -> Literal["uuid"]:
+        return "uuid"
+
+    @property
+    @override
+    def type(self) -> type[UUID]:
+        return UUID
+
+    @override
+    def construct_array_type(self) -> type[UuidArray | ArrowUuidArray]:
+        return UuidArray if self.storage == "numpy" else ArrowUuidArray
 
     # ExtensionDtype overrides
 
@@ -132,7 +150,7 @@ class UuidDtype(ExtensionDtype):
 
     # IO
 
-    def __from_arrow__(self, array: pa.Array | pa.ChunkedArray) -> UuidExtensionArray:
+    def __from_arrow__(self, array: pa.Array | pa.ChunkedArray) -> ArrowExtensionArray:
         """PyArrow extension API for :meth:`pyarrow.Array.to_pandas`.
 
         Incomplete because :meth:`pyarrow.UuidType.to_pandas_dtype`
@@ -140,15 +158,27 @@ class UuidDtype(ExtensionDtype):
 
         See :ref:`pyarrow-integration` for an example.
         """
-        return UuidExtensionArray(array)
+        return ArrowExtensionArray(array)
 
 
-class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
-    """Pandas extension array for UUIDs."""
+class BaseUuidArray(ExtensionArray, abc.ABC):
+    """Base class for :class:`~pandas_uuid.UuidArray` and :class:`~pandas_uuid.ArrowUuidArray`."""  # noqa: E501
+
+    # Non-essential overrides
+
+    @property
+    @override
+    def shape(self) -> tuple[int, ...]:
+        return (len(self),)
+
+
+class UuidArray(BaseUuidArray, NumpyExtensionArray):  # noqa: PLW1641
+    """Extension array for string data in a :class:`numpy.ndarray`."""
 
     # Implementation details and convenience
 
-    _data: _UuidStorageArray
+    _typ = "extension"  # undo numpy extension array hack
+    _ndarray: NDArray[np.void]
 
     def __init__(
         self,
@@ -161,9 +191,14 @@ class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
 
         Constructing from a :type:`UuidStorage` is fast.
         """
-        if not isinstance(dtype, UuidDtype | None):
-            msg = f"{type(self).__name__!r} only supports `UuidDtype` dtype"
-            raise TypeError(msg)
+        if not isinstance(dtype, UuidDtype | None) or (
+            dtype is not None and dtype.storage != "numpy"
+        ):
+            msg = (
+                f"{type(self).__name__!r} only supports `UuidDtype(storage='numpy')`, "
+                f"not {dtype}"
+            )
+            raise ValueError(msg)
 
         # TODO: implement conversion between storage kinds
         # https://github.com/scverse/pandas-uuid/issues/12
@@ -172,57 +207,32 @@ class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
         if isinstance(values, np.ndarray) and values.dtype.kind != "O":
             if dtype is not None and dtype.storage != "numpy":
                 raise NotImplementedError
-            self._data = values.astype(_UUID_NP_STORAGE_DTYPE, copy=copy)
-        elif isinstance(values, pa.Array):
-            if dtype is not None and dtype.storage != "pyarrow":
-                raise NotImplementedError
-            from pyarrow import uuid
-
-            self._data = values.cast(uuid())
-
-        # TODO: make construction from elements more efficient
-        #       (both numpy and pyarrow)
-        # https://github.com/scverse/pandas-uuid/issues/2
-        elif (dtype is None and find_spec("pyarrow")) or (
-            dtype is not None and dtype.storage == "pyarrow"
-        ):
-            from pyarrow import array, binary, uuid
-
-            # cast because of https://github.com/apache/arrow/issues/48470
-            self._data = array(
-                [
-                    None if pd.isna(x) else _to_uuid_pyarrow(x).cast(binary(16))
-                    for x in values
-                ],
-                type=uuid(),
-            )
+            values = values.astype(_UUID_NP_STORAGE_DTYPE, copy=copy)
         else:
-            self._data = np.array(
+            # TODO: make construction from elements more efficient
+            #       (both numpy and pyarrow)
+            # https://github.com/scverse/pandas-uuid/issues/2
+            values = np.array(
                 [_to_uuid_numpy(x).bytes for x in values],
                 dtype=_UUID_NP_STORAGE_DTYPE,
             )
 
-        if getattr(self._data, "ndim", 1) != 1:
+        if getattr(self._ndarray, "ndim", 1) != 1:
             msg = "Array only supports 1-d arrays"
             raise ValueError(msg)
+
+        super().__init__(values)
 
     # ExtensionArray essential API (11 class attrs and methods)
 
     @property
     @override
-    def dtype(self) -> UuidDtype:
-        match self._data:
-            case pa.Array():
-                return UuidDtype(storage="pyarrow")
-            case np.ndarray():
-                return UuidDtype(storage="numpy")
-            case _:  # pragma: no cover
-                msg = f"Unknown storage type: {type(self._data)}"
-                raise AssertionError(msg)
+    def dtype(self) -> UuidDtype:  # pyright: ignore[reportIncompatibleMethodOverride]
+        return UuidDtype(storage="numpy")
 
     @override
     @classmethod
-    def _from_sequence(  # pyright: ignore[reportGeneralTypeIssues]
+    def _from_sequence(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls,
         scalars: Iterable[UuidLike],
         *,
@@ -238,46 +248,16 @@ class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
     @override
     def __getitem__(self, item: ScalarIndexer | SequenceIndexer) -> Self | UUID:
         if isinstance(item, int | np.integer):
-            match self._data[item]:
-                case pa.UuidScalar() as elem:
-                    return elem.as_py()
-                case np.void() as elem:
-                    return UUID(bytes=elem.tobytes())
-                case elem:  # pragma: no cover
-                    msg = f"Unknown type in storage: {type(elem)}"
-                    raise AssertionError(msg)
+            elem = cast("np.void", self._ndarray[item])
+            return UUID(bytes=elem.tobytes())
         item = check_array_indexer(self, item)
-        if (
-            isinstance(item, np.ndarray)
-            and item.dtype.kind == "b"
-            and isinstance(self._data, pa.Array | pa.ChunkedArray)
-        ):
-            return self._simple_new(self._data.filter(item))
-
-        match self._data, item:
-            case (np.ndarray(), _):
-                values = self._data[item]
-            case pa.Array(), slice() if (
-                item.step in {1, None}
-                and isinstance(item.start, int | None)
-                and isinstance(item.stop, int | None)
-            ):
-                start = item.start if item.start is not None else 0
-                length = item.stop - start if item.stop is not None else None
-                values = self._data.slice(start, length)
-            case pa.Array(), slice():
-                item = np.array(range(len(self._data))[item])
-                values = self._data.take(item)
-            case pa.Array(), np.ndarray():
-                values = self._data.take(item)
-
-        return self._simple_new(values)
+        return self._simple_new(self._ndarray[item])
 
     # def __setitem__(self, index, value):
 
     @override
     def __len__(self) -> int:
-        return len(self._data)
+        return len(self._ndarray)
 
     @unpack_zerodim_and_defer("__eq__")
     @override
@@ -287,103 +267,80 @@ class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
     @property
     @override
     def nbytes(self) -> int:
-        return self._data.nbytes
+        return self._ndarray.nbytes
 
     @override
     def isna(self) -> NDArray[np.bool_]:
-        return pd.isna(self._data)
+        return pd.isna(self._ndarray)
 
     @override
     def take(
         self,
-        indexer: TakeIndexer,
+        indices: TakeIndexer,
         *,
         allow_fill: bool = False,
         fill_value: UUID | NAType | None = None,
+        axis: AxisInt = 0,
     ) -> Self:
-        if self.dtype.storage == "pyarrow":
-            # TODO: implement take for pyarrow
-            # https://github.com/scverse/pandas-uuid/issues/11
-            raise NotImplementedError
-
         if allow_fill and fill_value is None:
             fill_value = self.dtype.na_value
 
-        if (
-            self.dtype.storage == "numpy"
-            and allow_fill
-            and not isinstance(fill_value, UUID)
-        ):  # pandas’ take will create an object array which is not supported
+        if allow_fill and not isinstance(fill_value, UUID):
+            # pandas’ take will create an object array which is not supported
             raise NotImplementedError
 
-        result = take(self._data, indexer, allow_fill=allow_fill, fill_value=fill_value)
+        result = take(
+            self._ndarray, indices, allow_fill=allow_fill, fill_value=fill_value
+        )
         return self._simple_new(result)
 
     @override
-    def copy(self) -> Self:
-        return self._simple_new(
-            self._data.copy() if isinstance(self._data, np.ndarray) else self._data
-        )
+    def copy(self, order: Literal["C", "F", "A", "K"] = "C") -> Self:
+        return self._simple_new(self._ndarray.copy(order))
 
     @override
     @classmethod
-    def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # pyright: ignore[reportGeneralTypeIssues]
+    def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
         if len(to_concat) == 0:
             return cls([])
-        if isinstance(to_concat[0]._data, np.ndarray):  # noqa: SLF001
-            values = np.concatenate([x._data for x in to_concat])  # noqa: SLF001
-        else:
-            from pyarrow import concat_arrays
-
-            values = concat_arrays([x._data for x in to_concat])  # noqa: SLF001
+        values = np.concatenate([x._ndarray for x in to_concat])  # noqa: SLF001
         return cls._simple_new(values)
-
-    # Other overrides
-
-    @property
-    @override
-    def shape(self) -> tuple[int, ...]:
-        return (len(self),)
 
     # Helpers
 
+    @override
     @classmethod
-    def _simple_new(cls, values: _UuidStorageArray) -> Self:
-        result = UuidExtensionArray.__new__(cls)
-        result._data = values  # noqa: SLF001
-        return result
+    def _simple_new(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls, values: NDArray[np.void], dtype: UuidDtype | None = None
+    ) -> Self:
+        if dtype is None:
+            dtype = UuidDtype(storage="numpy")
+        elif not isinstance(dtype, UuidDtype) or dtype.storage != "numpy":
+            msg = (
+                f"{type(cls).__name__!r} only supports `UuidDtype(storage='numpy')`, "
+                f"not {dtype}"
+            )
+            raise ValueError(msg)
+        return super()._simple_new(values, dtype=dtype)
 
-    def _cmp(
-        self, op: str, other: Sequence[UuidLike] | UuidExtensionArray
-    ) -> BooleanArray:
-        if not isinstance(other, UuidExtensionArray):
-            other = cast("UuidExtensionArray", pd.array(other, dtype=self.dtype))  # pyright: ignore[reportAssignmentType]
+    def _cmp(self, op: str, other: Sequence[UuidLike] | UuidArray) -> BooleanArray:
+        if not isinstance(other, UuidArray):
+            other = cast("UuidArray", pd.array(other, dtype=self.dtype))  # pyright: ignore[reportAssignmentType]
 
-        match self._data, other._data:  # noqa: SLF001
-            case pa.Array(), pa.Array():
-                if op != "eq":  # pragma: no cover
-                    raise NotImplementedError
-
-                from pyarrow import binary, compute
-
-                result = compute.equal(
-                    self._data.view(binary(16)),
-                    other._data.view(binary(16)),  # noqa: SLF001
-                )
-            case np.ndarray(), np.ndarray():
-                method = getattr(self._data, f"__{op}__")
-                result = method(other._data.view(np.void(16)))  # noqa: SLF001
-            case _:  # pragma: no cover
-                raise NotImplementedError
-
+        method = getattr(self._ndarray, f"__{op}__")
+        result = method(other._ndarray.view(np.void(16)))  # noqa: SLF001
         return cast("BooleanArray", pd.array(result, dtype="boolean"))
 
     # IO
 
+    @overload
+    def __arrow_array__(self, type: None = None) -> pa.Array[pa.UuidScalar]: ...
+    @overload
+    def __arrow_array__(self, type: _DT) -> pa.Array[pa.Scalar[_DT]]: ...
     def __arrow_array__(
         self,
-        type: pa.DataType | None = None,  # noqa: A002
-    ) -> pa.Array | pa.ChunkedArray:
+        type: _DT | None = None,  # noqa: A002
+    ) -> pa.Array[pa.Scalar[_DT]] | pa.ChunkedArray[pa.Scalar[_DT]]:
         """PyArrow extension API for :meth:`pyarrow.Array.from_pandas`.
 
         See :ref:`pyarrow-integration` for an example
@@ -392,8 +349,216 @@ class UuidExtensionArray(ExtensionArray):  # noqa: PLW1641
         import pyarrow as pa
 
         if type is None:
-            type = pa.uuid()  # noqa: A001
+            type = pa.uuid()  # pyright: ignore[reportAssignmentType] # noqa: A001
 
-        if isinstance(self._data, pa.Array | pa.ChunkedArray):
-            return self._data.cast(type)
-        return pa.array(self._data, type=type)
+        return pa.array(self._ndarray, type=type)  # pyright: ignore[reportReturnType]
+
+
+class ArrowUuidArray(BaseUuidArray, ArrowExtensionArray):  # noqa: PLW1641
+    """Extension array for uuid data in a :class:`pyarrow.ChunkedArray`."""
+
+    _pa_array: pa.ChunkedArray[pa.Scalar[pa.UuidType]]
+    _dtype: UuidDtype
+
+    def __init__(
+        self,
+        values: Iterable[UuidLike | NAType | None],
+        *,
+        dtype: UuidDtype | None = None,
+    ) -> None:
+        """Initialize the array from an iterable of UUIDs.
+
+        Constructing from a :type:`UuidStorage` is fast.
+        """
+        if not isinstance(dtype, UuidDtype | None) or (
+            dtype is not None and dtype.storage != "pyarrow"
+        ):
+            msg = (
+                f"{type(self).__name__!r} only supports `UuidDtype(storage='pyarrow')`, "  # noqa: E501
+                f"not {dtype}"
+            )
+            raise ValueError(msg)
+
+        self._dtype = UuidDtype(storage="pyarrow")  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        import pyarrow as pa
+
+        # TODO: implement conversion between storage kinds
+        # https://github.com/scverse/pandas-uuid/issues/12
+
+        if isinstance(values, pa.Array | pa.ChunkedArray):
+            if dtype is not None and dtype.storage != "pyarrow":
+                raise NotImplementedError
+
+            self._pa_array = (
+                pa.chunked_array([values.cast(pa.uuid())])
+                if isinstance(values, pa.Array)
+                else values.cast(pa.uuid())
+            )
+        else:
+            # TODO: make construction from elements more efficient
+            #       (both numpy and pyarrow)
+            # https://github.com/scverse/pandas-uuid/issues/2
+            # cast because of https://github.com/apache/arrow/issues/48470
+            chunk = pa.array(
+                [
+                    None if pd.isna(x) else _to_uuid_pyarrow(x).cast(pa.binary(16))
+                    for x in values
+                ],
+                type=pa.uuid(),
+            )
+            self._pa_array = pa.chunked_array([chunk])
+
+    # ExtensionArray essential API (11 class attrs and methods)
+
+    @property
+    @override
+    def dtype(self) -> UuidDtype:  # pyright: ignore[reportIncompatibleMethodOverride]
+        return UuidDtype(storage="pyarrow")
+
+    @override
+    @classmethod
+    def _from_sequence(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls,
+        scalars: Iterable[UuidLike],
+        *,
+        dtype: UuidDtype | None = None,
+        copy: bool = False,
+    ) -> Self:
+        del copy  # part of the API, but underlying array is readonly
+        return cls(scalars, dtype=dtype)
+
+    @overload
+    def __getitem__(self, item: ScalarIndexer) -> UUID: ...
+    @overload
+    def __getitem__(self, item: SequenceIndexer) -> Self: ...
+    @override
+    def __getitem__(self, item: ScalarIndexer | SequenceIndexer) -> Self | UUID:
+        if isinstance(item, int | np.integer):
+            elem = cast("pa.UuidScalar", self._pa_array[item])  # pyright: ignore[reportArgumentType, reportCallIssue]
+            return elem.as_py()
+
+        item = check_array_indexer(self, item)
+        match item:
+            case slice() if (
+                item.step in {1, None}
+                and isinstance(item.start, int | None)
+                and isinstance(item.stop, int | None)
+            ):
+                start = item.start if item.start is not None else 0
+                length = item.stop - start if item.stop is not None else None
+                values = self._pa_array.slice(start, length)
+            case slice():
+                item = np.array(range(len(self._pa_array))[item])
+                values = self._pa_array.take(item)
+            case np.ndarray() if item.dtype.kind == "b":
+                values = self._pa_array.filter(item)
+            case np.ndarray():
+                values = self._pa_array.take(item)
+            case _:
+                msg = f"Unexpected indexer type: {type(item)}"
+                raise AssertionError(msg)
+
+        return self._simple_new(values)
+
+    # def __setitem__(self, index, value):
+
+    @override
+    def __len__(self) -> int:
+        return len(self._pa_array)
+
+    @unpack_zerodim_and_defer("__eq__")
+    @override
+    def __eq__(self, other: Sequence[UuidLike] | ArrowUuidArray) -> BooleanArray:  # pyright: ignore[reportIncompatibleMethodOverride]
+        return self._cmp("eq", other)
+
+    @property
+    @override
+    def nbytes(self) -> int:
+        return self._pa_array.nbytes
+
+    @override
+    def isna(self) -> NDArray[np.bool_]:
+        return self._pa_array.is_null().to_numpy()
+
+    @override
+    def take(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        indices: TakeIndexer,
+        *,
+        allow_fill: bool = False,
+        fill_value: UUID | NAType | None = None,
+    ) -> Self:
+        # TODO: implement take for pyarrow
+        # https://github.com/scverse/pandas-uuid/issues/11
+        raise NotImplementedError
+
+    @override
+    def copy(self) -> Self:
+        return self._simple_new(
+            self._pa_array.copy()
+            if isinstance(self._pa_array, np.ndarray)
+            else self._pa_array
+        )
+
+    @override
+    @classmethod
+    def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # pyright: ignore[reportIncompatibleMethodOverride]
+        if len(to_concat) == 0:
+            return cls([])
+        import pyarrow as pa
+
+        # is there a pa.concat_arrays for chunked ones?
+        values = pa.chunked_array(
+            [chunk for x in to_concat for chunk in x._pa_array.chunks]  # noqa: SLF001
+        )
+        return cls._simple_new(values)
+
+    # Helpers
+
+    @classmethod
+    def _simple_new(
+        cls,
+        values: pa.ChunkedArray[pa.Scalar[pa.UuidType]],
+    ) -> Self:
+        result = ArrowUuidArray.__new__(cls)
+        result._pa_array = values  # noqa: SLF001
+        return result
+
+    def _cmp(self, op: str, other: Sequence[UuidLike] | ArrowUuidArray) -> BooleanArray:
+        if not isinstance(other, ArrowUuidArray):
+            other = cast("ArrowUuidArray", pd.array(other, dtype=self.dtype))  # pyright: ignore[reportAssignmentType]
+
+        if op != "eq":  # pragma: no cover
+            raise NotImplementedError
+
+        import pyarrow as pa
+        from pyarrow import compute
+
+        result = compute.equal(
+            self._pa_array.cast(pa.binary(16)),
+            other._pa_array.cast(pa.binary(16)),  # noqa: SLF001
+        )
+        return cast("BooleanArray", pd.array(result, dtype="boolean"))  # pyright: ignore[reportArgumentType]
+
+    # IO
+
+    @overload
+    def __arrow_array__(self, type: None = None) -> pa.Array[pa.UuidScalar]: ...
+    @overload
+    def __arrow_array__(self, type: _DT) -> pa.Array[pa.Scalar[_DT]]: ...
+    def __arrow_array__(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        type: _DT | None = None,  # noqa: A002
+    ) -> pa.Array[pa.Scalar[_DT]] | pa.ChunkedArray[pa.Scalar[_DT]]:
+        """PyArrow extension API for :meth:`pyarrow.Array.from_pandas`.
+
+        See :ref:`pyarrow-integration` for an example
+        and :ref:`pyarrow:arrow_array_protocol` for details.
+        """
+        import pyarrow as pa
+
+        if type is None:
+            type = pa.uuid()  # pyright: ignore[reportAssignmentType] # noqa: A001
+
+        return self._pa_array.cast(type)  # pyright: ignore[reportReturnType]

--- a/src/pandas_uuid/_pyarrow.py
+++ b/src/pandas_uuid/_pyarrow.py
@@ -11,8 +11,10 @@ __all__ = [
     "ChunkedArray",
     "DataType",
     "ExtensionArray",
+    "Scalar",
     "UuidArray",
     "UuidScalar",
+    "UuidType",
 ]
 
 
@@ -22,8 +24,10 @@ if TYPE_CHECKING or find_spec("pyarrow"):
         ChunkedArray,
         DataType,
         ExtensionArray,
+        Scalar,
         UuidArray,
         UuidScalar,
+        UuidType,
     )
 
     HAS_PYARROW = True
@@ -32,7 +36,9 @@ else:  # pragma: no cover
     ChunkedArray = type("ChunkedArray", (), dict(__module__="pyarrow"))
     DataType = type("DataType", (), dict(__module__="pyarrow"))
     ExtensionArray = type("ExtensionArray", (), dict(__module__="pyarrow"))
+    Scalar = type("Scalar", (), dict(__module__="pyarrow"))
     UuidArray = type("UuidArray", (), dict(__module__="pyarrow"))
     UuidScalar = type("UuidScalar", (), dict(__module__="pyarrow"))
+    UuidType = type("UuidType", (), dict(__module__="pyarrow"))
 
     HAS_PYARROW = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,10 +35,10 @@ def test_isna(storage: UuidStorage, xfail_if_numpy_and_na: Callable[..., None]) 
     [
         pytest.param([u0 := uuid4()], 0, u0, id="only-py"),
         pytest.param([u1 := uuid4()], np.int64(0), u1, id="only-np"),
-        pytest.param([None], 0, None, id="only-na"),
+        pytest.param([pd.NA], 0, pd.NA, id="only-na"),
         pytest.param([u0, u1], 1, u1, id="second"),
         pytest.param([u0, u1], slice(None), [u0, u1], id="all-slice"),
-        pytest.param([None, u1], slice(None), [None, u1], id="all-slice-na"),
+        pytest.param([pd.NA, u1], slice(None), [pd.NA, u1], id="all-slice-na"),
         pytest.param([u0, u1], slice(None, None, -1), [u1, u0], id="inv-slice"),
         pytest.param([u0, u1], [0, 1], [u0, u1], id="all-list"),
         pytest.param([u0, u1], [1, 0], [u1, u0], id="all-list-reorder"),
@@ -56,6 +56,8 @@ def test_getitem(
     match expected:
         case list():
             assert arr[index].tolist() == expected
+        case _ if expected is pd.NA:
+            assert pd.isna(arr[index])
         case _:
             assert arr[index] == expected
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,7 +117,7 @@ def test_getitem_error(index: Any) -> None:  # noqa: ANN401
     [
         pytest.param([u0 := uuid4(), u1 := uuid4()], [u0, u1], [True] * 2, id="same"),
         pytest.param([u0, u1], [u0, u0], [True, False], id="different"),
-        pytest.param([u0, None], [u0, u1], [True, None], id="na"),
+        pytest.param([u0, pd.NA], [u0, u1], [True, pd.NA], id="na"),
     ],
 )
 @pytest.mark.parametrize("is_arr", ["left", "right", "none"])
@@ -141,7 +141,7 @@ def test_eq(
     if is_arr != "right":
         left = to_arr(left)
     arr_exp = pd.array(expected, dtype="boolean")
-    pd.testing.assert_extension_array_equal(left == right, arr_exp)  # pyright: ignore[reportArgumentType]
+    pd.testing.assert_extension_array_equal(left == right, arr_exp, check_dtype=False)  # pyright: ignore[reportArgumentType]
 
 
 def test_shape(storage: UuidStorage) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,11 @@ def test_isna(storage: UuidStorage, xfail_if_numpy_and_na: Callable[..., None]) 
     assert arr.isna().tolist() == [False, False, True]
 
 
+def test_isna_numpy() -> None:
+    arr = pd.array([uuid4(), uuid4()], dtype=UuidDtype("numpy"))
+    assert arr.isna().tolist() == [False, False]
+
+
 @pytest.mark.parametrize(
     ("values", "index", "expected"),
     [
@@ -97,7 +102,7 @@ def test_take(
 
 def test_take_fill(request: pytest.FixtureRequest, storage: UuidStorage) -> None:
     if storage == "numpy":
-        request.applymarker(pytest.mark.xfail(raises=NotImplementedError))
+        request.applymarker(pytest.mark.xfail(raises=ValueError))
     arr = pd.array([uuid4(), uuid4()], dtype=UuidDtype(storage))
     result = arr.take([1, -1], allow_fill=True).tolist()
     assert result == [arr[1], pd.NA]

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -95,6 +95,16 @@ def test_construct_array_error(
         api(arr)
 
 
+def test_simple_new_error() -> None:
+    with pytest.raises(ValueError, match=r"support.*UuidDtype"):
+        UuidArray._simple_new(np.ndarray([]), dtype=object)  # pyright: ignore[reportArgumentType]  # noqa: SLF001
+
+
+def test_from_backing_data_error() -> None:
+    with pytest.raises(ValueError, match=r"values.dtype.*V16"):
+        UuidArray([])._from_backing_data(np.ndarray([], dtype=object))  # pyright: ignore[reportArgumentType]  # noqa: SLF001
+
+
 try:
     import pyarrow as pa
 except ImportError:

--- a/tests/test_pyarrow_compat.py
+++ b/tests/test_pyarrow_compat.py
@@ -51,7 +51,8 @@ def test_pyarrow_to_pandas(api: Literal["pyarrow", "pandas"]) -> None:
         case "pandas":
             pd_ser = pd.Series(pa_arr, dtype=UuidDtype())  # pyright: ignore[reportArgumentType, reportCallIssue]
         case "pyarrow":
-            pd_ser = pa_arr.to_pandas(types_mapper={pa.uuid(): UuidDtype()}.get)  # pyright: ignore[reportArgumentType]
+            mapper = {pa.uuid(): UuidDtype()}.get
+            pd_ser = pa_arr.to_pandas(types_mapper=mapper)  # pyright: ignore[reportArgumentType]
 
     expected = pd.array(data, dtype=UuidDtype("pyarrow"))
     pd.testing.assert_extension_array_equal(pd_ser.array, expected)


### PR DESCRIPTION
pandas has dedicated base classes to use: `pandas.arrays.{Arrow,Numpy}ExtensionArray`

fixes #11